### PR TITLE
FW-08 Configure Vite Config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,14 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 export default defineConfig({
+  build: {
+    outDir: 'build',
+  },
   plugins: [react()],
+  server: {
+    open: true,
+    port: 3000,
+  },
   // @ts-ignore: to address the types later
   test: {
     globals: true,


### PR DESCRIPTION
## Rationale
Configuring the Vite config to outDir the build folder instead of dist and to spin up the app on PORT 3000 by default.

## Linting Checklist
- [x] No commented code
- [x] Code Formatted nicely (Prettier)
- [x] PR your own code before you assign reviewers